### PR TITLE
build: Use `implementation` instead of deprecated `compile` configuration.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
 }
 


### PR DESCRIPTION
On running `./gradlew help --scan` from my project's `android`
directory, most users will likely see the following deprecation
warning from Android Gradle Plugin (or, worse, it will eventually
become an error that fails the build):

```
> Configure project :react-native-text-input-reset

WARNING: Configuration 'compile' is obsolete and has been replaced
with 'implementation' and 'api'.

It will be removed soon. For more information see:
http://d.android.com/r/tools/update-dependency-configurations.html
```

Following that link to the documentation, we find that
`implementation` seems like the thing to choose; for `api`, they say
"you should use it with caution and only with dependencies that you
need to transitively export to other upstream consumers".

Also, a quick search through all dependencies in my own project's
`node_modules` shows that, for `com.facebook.react:react-native:`,
`implementation` is used in a large majority of cases; the
deprecated `compile` is used in just a few (including this one); and
`api` is used in just one, and that one happened with no explanation
at all [1], so was likely not well-considered.

[1] https://github.com/react-native-community/react-native-cameraroll/commit/d4a7ab719423de59350d0d6b9aa7ec8244738fe8

Fixes: #13